### PR TITLE
chore: use FormatDate instead of new Date()

### DIFF
--- a/apps/web/app/[slug]/page.tsx
+++ b/apps/web/app/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { getBaseUrl } from '@/lib/get-base-url'
 import { getSEOMetadata } from '@/lib/seo'
 import ArticleLoadingSkeleton from '@/components/article-loading-skeleton'
 import { WORDS_PER_MINUTE } from '@/lib/constants'
+import FormatDate from '@/components/format-date'
 
 import type { Metadata } from 'next'
 import type { WithContext, WebPage } from 'schema-dts'
@@ -89,8 +90,8 @@ export default async function PostPage({ params }: PageProps<'/[slug]'>) {
       height: '1080',
     },
     thumbnailUrl: articleImageUrl,
-    datePublished: new Date(data.publishedAt).toISOString(),
-    dateModified: new Date(data._updatedAt).toISOString(),
+    datePublished: data.publishedAt,
+    dateModified: data._updatedAt,
     description: data.excerpt,
     breadcrumb: {
       '@type': 'BreadcrumbList',
@@ -170,13 +171,7 @@ export default async function PostPage({ params }: PageProps<'/[slug]'>) {
               {data.sport && (data.division || data.conferences) && (
                 <span className="text-sm">•</span>
               )}
-              <time className="text-sm">
-                {new Date(data.publishedAt).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
-              </time>
+              <FormatDate dateString={data.publishedAt} />
             </div>
           </div>
         </section>

--- a/apps/web/app/privacy-policy/page.tsx
+++ b/apps/web/app/privacy-policy/page.tsx
@@ -1,5 +1,5 @@
 import PageHeader from '@/components/page-header'
-import Date from '@/components/date'
+import FormatDate from '@/components/format-date'
 import { RichText } from '@/components/rich-text'
 import { getSEOMetadata } from '@/lib/seo'
 import { sanityFetch } from '@/lib/sanity/live'
@@ -69,7 +69,7 @@ export default async function PrivacyPolicyPage() {
             title="Privacy Policy"
             subtitle={
               <p className="mt-4 text-lg font-normal lg:text-xl">
-                Last updated on <Date dateString={privacyPolicy._updatedAt} />
+                Last updated on <FormatDate dateString={privacyPolicy._updatedAt} />
               </p>
             }
           />

--- a/apps/web/components/article-card.tsx
+++ b/apps/web/components/article-card.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { Separator } from '@workspace/ui/components/separator'
 
 import CustomImage from './sanity-image'
-import Date from '@/components/date'
+import FormatDate from '@/components/format-date'
 
 import type { Slug } from '@/lib/sanity/sanity.types'
 
@@ -47,7 +47,7 @@ export default function ArticleCard({
         <div className="text-muted-foreground flex items-center space-x-2 text-sm">
           <div>{author}</div>
           <Separator orientation="vertical" className="h-4" />
-          <Date dateString={date} />
+          <FormatDate dateString={date} />
         </div>
       </div>
     </div>

--- a/apps/web/components/article-section.tsx
+++ b/apps/web/components/article-section.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from 'lucide-react'
 import { cn } from '@workspace/ui/lib/utils'
 import { buttonVariants } from '@workspace/ui/components/button'
 
-import Date from '@/components/date'
+import FormatDate from '@/components/format-date'
 import ArticleCard from '@/components/article-card'
 import CustomImage from '@/components/sanity-image'
 
@@ -72,7 +72,7 @@ export default function ArticleSection({
                   />
                   {firstArticle.authors[0]?.name}
                 </Link>
-                <Date dateString={firstArticle.publishedAt} />
+                <FormatDate dateString={firstArticle.publishedAt} />
               </div>
             </div>
           </div>

--- a/apps/web/components/format-date.tsx
+++ b/apps/web/components/format-date.tsx
@@ -9,7 +9,7 @@ interface DateProps extends WithClassName {
 
 const timeZone = 'America/Phoenix'
 
-export default function Date({ dateString, className }: DateProps) {
+export default function FormatDate({ dateString, className }: DateProps) {
   const date = parseISO(dateString)
 
   return (

--- a/apps/web/components/home/hero.tsx
+++ b/apps/web/components/home/hero.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-import Date from '@/components/date'
+import FormatDate from '@/components/format-date'
 import ArticleCard from '@/components/article-card'
 import CustomImage from '../sanity-image'
 import { QueryHomePageDataResult } from '@/lib/sanity/sanity.types'
@@ -41,7 +41,7 @@ const Hero = ({ heroPosts }: { heroPosts: QueryHomePageDataResult }) => {
                   />
                   <span className="text-primary">{heroArticle.authors[0]?.name}</span>
                 </Link>
-                <Date dateString={heroArticle.publishedAt} />
+                <FormatDate dateString={heroArticle.publishedAt} />
               </div>
             </div>
           </div>

--- a/apps/web/components/json-ld.tsx
+++ b/apps/web/components/json-ld.tsx
@@ -63,8 +63,8 @@ export function ArticleJsonLd({ article }: { article: any }) {
         })
       : [],
     headline: article.title,
-    datePublished: new Date(article.publishedAt).toISOString(),
-    dateModified: new Date(article._updatedAt).toISOString(),
+    datePublished: article.publishedAt,
+    dateModified: article._updatedAt,
     description: article.excerpt,
     mainEntityOfPage: {
       '@type': 'WebPage',

--- a/apps/web/components/search-bar.tsx
+++ b/apps/web/components/search-bar.tsx
@@ -6,6 +6,7 @@ import { Search, X } from 'lucide-react'
 import { Input } from '@workspace/ui/components/input'
 import { Button } from '@workspace/ui/components/button'
 import { Card } from '@workspace/ui/components/card'
+
 import { useDebounce } from '@/hooks/use-debounce'
 import { client } from '@/lib/sanity/client'
 
@@ -53,15 +54,6 @@ const realSearch = async (query: string): Promise<any> => {
     console.error('Search error:', error)
     return []
   }
-}
-
-const formatDate = (dateString: string) => {
-  const date = new Date(dateString)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
 }
 
 export function SearchBar({ placeholder = 'Search...', className }: SearchBarProps) {
@@ -198,9 +190,6 @@ export function SearchBar({ placeholder = 'Search...', className }: SearchBarPro
                   >
                     <div className="flex flex-col">
                       <div className="line-clamp-2 text-sm font-medium">{result.title}</div>
-                      <div className="text-muted-foreground mt-1 text-xs">
-                        {formatDate(result.publishedAt)}
-                      </div>
                     </div>
                   </button>
                 ))}


### PR DESCRIPTION
So this uses `FormateDate` (used to be `Date`) instead of doing `new Date()`. It also removes doing `new Date()` for the `publishedAt` and `_updatedAt` fields in the `ld+json` scripts. The only one I couldn't really remove is to get the copyright year.

I am doing this because https://vercel.com/docs/incremental-static-regeneration/limits-and-pricing#optimizing-isr-reads-and-writes