### PR TITLE
feat: add api for loading season data

### DIFF
--- a/apps/web/app/api/admin/data-loaders/[sport]/seasons/route.ts
+++ b/apps/web/app/api/admin/data-loaders/[sport]/seasons/route.ts
@@ -1,0 +1,33 @@
+import { SportParam } from '@/utils/espn'
+import { fetchAndLoadSeasons } from '@/utils/loaders'
+import { NextResponse } from 'next/server'
+
+const validSports = ['football', 'mens-basketball', 'womens-basketball']
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ sport: SportParam }> },
+) {
+  const { sport: sportSlug } = await params
+  if (!validSports.includes(sportSlug)) {
+    return NextResponse.json(
+      {
+        error: 'Invalid sport',
+      },
+      { status: 400 },
+    )
+  }
+  try {
+    await fetchAndLoadSeasons(sportSlug)
+  } catch (e) {
+    console.log(e)
+    return NextResponse.json(
+      {
+        error: e,
+      },
+      { status: 400 },
+    )
+  }
+
+  return NextResponse.json({ result: 'ok' })
+}


### PR DESCRIPTION
Follow up to #132 that makes the loaders available via an API