### PR TITLE
chore: import defineLive from next-sanity/live

### DIFF
--- a/apps/web/lib/sanity/live.ts
+++ b/apps/web/lib/sanity/live.ts
@@ -1,4 +1,4 @@
-import { defineLive } from 'next-sanity'
+import { defineLive } from 'next-sanity/live'
 
 import { client } from './client'
 import { token } from './token'


### PR DESCRIPTION
Looks like they updated `defineLive` to be imported from `next-sanity/live` and will deprecate it from being imported from `next-sanity`.