### PR TITLE
chore: add division to sport subgrouping

### DIFF
--- a/apps/studio/schemaTypes/documents/sport-subgrouping.ts
+++ b/apps/studio/schemaTypes/documents/sport-subgrouping.ts
@@ -51,11 +51,18 @@ export const sportSubgrouping = defineType({
       validation: (rule) =>
         rule.required().min(1).error('At least one applicable sport is required.'),
     }),
+    defineField({
+      name: 'parentDivision',
+      title: 'Parent Division',
+      type: 'reference',
+      to: { type: 'division' },
+      validation: (rule) => rule.required(),
+    }),
   ],
   preview: {
     select: {
       title: 'name',
-      subtitle: 'applicableSport.title',
+      subtitle: 'parentDivision.title',
     },
     prepare: ({ title, subtitle }) => ({
       title,


### PR DESCRIPTION
Allows for FCS and FBS to have a parent relation to D1