### PR TITLE
chore: remove packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@redshirt-sports/root",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22",
+    "pnpm": ">=10.15.0"
   },
   "scripts": {
     "build": "turbo build",


### PR DESCRIPTION
Seeing if there's a way that we don't need `packageManager`, because it's annoying to get a warning when installing that a newer version is being used purely due to having a set version in `packageManager`.