### PR TITLE
Feature/update sanity studio

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -16,6 +16,7 @@ import { BlockContentInput } from './components/block-content-input'
 import { Logo } from './components/logo'
 import { schemaTypes } from './schemaTypes'
 import { getDefaultDocumentNode, structure } from './structure'
+import { createCustomPostDuplicateAction } from './utils/actions'
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID ?? ''
 const dataset = process.env.SANITY_STUDIO_DATASET
@@ -83,6 +84,14 @@ export default defineConfig({
       }
       return prev
     },
+    actions: (actions, context) =>
+      context.schemaType === 'post'
+        ? actions.map((actionItem) =>
+            actionItem.action === 'duplicate'
+              ? createCustomPostDuplicateAction(actionItem)
+              : actionItem,
+          )
+        : actions,
   },
   schema: {
     types: schemaTypes,

--- a/apps/studio/structure.ts
+++ b/apps/studio/structure.ts
@@ -35,23 +35,42 @@ type CreateSingleTon = {
   S: StructureBuilder
 } & Base<SingletonType>
 
-const incomingReferences = (S: StructureBuilder) =>
+const postReferences = (S: StructureBuilder) =>
   S.view
     .component(DocumentsPane)
     .options({
-      query: `*[references($id)] | order(_createdAt desc)`,
+      query: `*[_type == 'post' && references($id)] | order(_createdAt desc)`,
       params: { id: `_id` },
       useDraft: false,
     })
-    .title('Incoming References')
+    .title('Post References')
+    .icon(LinkIcon)
+
+const schoolReferences = (S: StructureBuilder) =>
+  S.view
+    .component(DocumentsPane)
+    .options({
+      query: `*[_type == 'school' && references($id)] | order(_createdAt desc)`,
+      params: { id: `_id` },
+      useDraft: false,
+    })
+    .title('School References')
     .icon(LinkIcon)
 
 export const getDefaultDocumentNode: DefaultDocumentNodeResolver = (S, { schemaType }) => {
   switch (schemaType) {
     case 'post':
-      return S.document().views([S.view.form().icon(ComposeIcon), incomingReferences(S)])
+      return S.document().views([S.view.form().icon(ComposeIcon), postReferences(S)])
+    case 'conference':
+      return S.document().views([
+        S.view.form().icon(ComposeIcon),
+        postReferences(S),
+        schoolReferences(S),
+      ])
+    case 'school':
+      return S.document().views([S.view.form().icon(ComposeIcon), postReferences(S)])
     default:
-      return S.document().views([S.view.form(), incomingReferences(S)])
+      return S.document().views([S.view.form()])
   }
 }
 

--- a/apps/studio/utils/actions.ts
+++ b/apps/studio/utils/actions.ts
@@ -1,0 +1,12 @@
+import { type DuplicateDocumentActionComponent } from 'sanity'
+
+export function createCustomPostDuplicateAction(
+  originalAction: DuplicateDocumentActionComponent,
+): DuplicateDocumentActionComponent {
+  return function CustomDuplicateAction(props) {
+    return originalAction({
+      ...props,
+      mapDocument: ({ slug, publishedAt, ...document }) => document,
+    })
+  }
+}


### PR DESCRIPTION
This PR aims to improve some of the user experience in the studio. The first commit updates the structure to get rid of the "Catch All" document page of "Incoming References" for more selective references like posts and schools. Furthermore, it removes the default of adding incoming references to ALL documents. For example, no one is going to be referencing an Author or Privacy Policy.

<img width="736" height="243" alt="Screenshot 2025-09-24 at 12 23 28" src="https://github.com/user-attachments/assets/a154111c-bd94-4da5-b4de-58b895d77cc0" />
<img width="951" height="235" alt="Screenshot 2025-09-24 at 12 23 47" src="https://github.com/user-attachments/assets/ae9ef4cf-0e83-473c-ae71-42c636c62afc" />

The second commit isn't one that is easily captured, but it updates the "Duplicate" functionality for the post document type only. One of the editors hated that the `publishedAt` field was also duplicated when copying a document as they would get in the flow and forget to update it. So I removed it plus removed the `slug` so they still have to generate something that is required as the `publishedAt` is going to become not required soon once we automate that.