### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/apps/web/app/api/vote/college/[sport]/rankings/[division]/route.ts
+++ b/apps/web/app/api/vote/college/[sport]/rankings/[division]/route.ts
@@ -247,7 +247,7 @@ export async function POST(
       return new Response(
         JSON.stringify({
           error: 'Invalid request data',
-          details: error,
+          details: error instanceof z.ZodError ? error.format() : undefined,
         }),
         {
           status: 400,


### PR DESCRIPTION
Potential fix for [https://github.com/JamesSingleton/redshirt-sports/security/code-scanning/1](https://github.com/JamesSingleton/redshirt-sports/security/code-scanning/1)

To fix the vulnerability, we should avoid sending the entire error object in the API response. Instead, return a minimal and generic description about the validation error to the client. If additional detail is required (for example: which field(s) failed validation), provide only the necessary safe subset from the error, such as a list of paths and generic messages, omitting stack traces and internal structures. For Zod errors, the `format()` method provides a minimal, serializable summary of validation issues, which is safe compared to the full object or a stack trace. The fix should change line 250 in the catch block to send either no `details` or, if more granularity is desired, include only error paths and generic messages. No changes are needed outside this region.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
