### PR TITLE
feat: article section per sport & auto populate sport

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -95,5 +95,17 @@ export default defineConfig({
   },
   schema: {
     types: schemaTypes,
+    templates: (prev) => [
+      ...prev,
+      {
+        id: 'post-by-sport',
+        title: 'Post by Sport',
+        schemaType: 'post',
+        parameters: [{ name: 'sportId', type: 'string' }],
+        value: ({ sportId }: { sportId: string }) => ({
+          sport: { _type: 'reference', _ref: sportId },
+        }),
+      },
+    ],
   },
 })


### PR DESCRIPTION
This updates the studio to have a section for:
- All Articles
- Football Articles
- Men's Basketball Articles
- Women's Basketball Articles

This will keep growing as we add sports as well.
<img width="351" height="246" alt="Screenshot 2025-10-05 at 13 54 21" src="https://github.com/user-attachments/assets/0d4a8b9b-ce1f-42e9-9f42-5a312800e195" />

Furthermore, this will auto-populate the sport field when creating a new post when in one of the `${sport} Articles` sections.
