### PR TITLE
fix: fix author image not being fully rounded

### DIFF
--- a/apps/web/app/authors/[slug]/page.tsx
+++ b/apps/web/app/authors/[slug]/page.tsx
@@ -175,9 +175,10 @@ export default async function Page({ params, searchParams }: PageProps<'/authors
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-6">
               <CustomImage
                 image={author.image}
-                className="h-20 w-20 shrink-0 rounded-full object-contain"
+                className="size-20 shrink-0 rounded-full"
                 width={80}
                 height={80}
+                mode="cover"
               />
               <div>
                 <span className="text-brand-500 dark:text-brand-400 block text-base font-semibold">


### PR DESCRIPTION
This updates the author image on `/authors/[slug]` to be fully rounded.

## Before
<img width="1080" height="267" alt="Screenshot 2025-10-05 at 16 25 37" src="https://github.com/user-attachments/assets/71222b05-3f38-48d4-afad-1175dbe5da7e" />

## After
<img width="1060" height="274" alt="Screenshot 2025-10-05 at 16 25 57" src="https://github.com/user-attachments/assets/cf87a340-561c-48a9-85c0-11ed52a9db84" />
