### PR TITLE
fix: fix author roles getting too close to article

### DIFF
--- a/apps/web/components/posts/author.tsx
+++ b/apps/web/components/posts/author.tsx
@@ -18,17 +18,15 @@ export const AuthorItem = (author: PostAuthor) => {
       />
       <div className="flex flex-col items-stretch justify-start gap-0.5">
         {author.archived ? (
-          <p className="mr-1 text-sm font-semibold tracking-[-.01em] whitespace-nowrap">
-            {author.name}
-          </p>
+          <p className="mr-1 text-sm font-semibold tracking-[-.01em]">{author.name}</p>
         ) : (
           <Link href={`/authors/${author.slug}`} prefetch={false}>
-            <p className="mr-1 text-sm font-semibold tracking-[-.01em] whitespace-nowrap hover:underline">
+            <p className="mr-1 text-sm font-semibold tracking-[-.01em] hover:underline">
               {author.name}
             </p>
           </Link>
         )}
-        <p className="text-muted-foreground min-h-4 text-sm/4 font-normal tracking-[-.01em] whitespace-nowrap">
+        <p className="text-muted-foreground min-h-4 text-sm/4 font-normal tracking-[-.01em]">
           {author.roles.join(', ')}
         </p>
       </div>


### PR DESCRIPTION
This fixes a scenario where author roles were getting a little too close to the articles for comfort. Nothing really changed on the mobile breakpoint, but I included it anyways.

## Before
<img width="1513" height="879" alt="Screenshot 2025-10-05 at 16 34 48" src="https://github.com/user-attachments/assets/c9516560-167e-4686-ab48-2e09aa4b4a1e" />
<img width="414" height="399" alt="Screenshot 2025-10-05 at 16 35 53" src="https://github.com/user-attachments/assets/c8b18b7f-7e2e-43d7-957f-9c7128e7b0bc" />


## After
<img width="1541" height="853" alt="Screenshot 2025-10-05 at 16 35 09" src="https://github.com/user-attachments/assets/a401d352-717f-4567-ad20-409e351f0818" />
<img width="420" height="406" alt="Screenshot 2025-10-05 at 16 35 28" src="https://github.com/user-attachments/assets/27d1b160-e018-4259-aa06-5758fae8cfc9" />
